### PR TITLE
update the daily quote calculation to align with the user’s local time instead of UTC.

### DIFF
--- a/src/app/components/daily-quote/daily-quote.component.ts
+++ b/src/app/components/daily-quote/daily-quote.component.ts
@@ -22,31 +22,47 @@ export class DailyQuoteComponent {
 
   constructor(private store: Store) {
     this.loading$ = this.store.select(selectAllQuotesLoading);
-
-    this.loading$ = this.store.select(selectAllQuotesLoading);
     this.quoteOfTheDay$ = this.store.select(selectAllQuotes).pipe(
       map((quotes) => this.getQuoteOfTheDay(quotes)),
       filter((quote): quote is Quote => quote !== undefined)
     );
   }
 
-  private getQuoteOfTheDay(quotes: Quote[]): Quote | undefined {
-    if (!quotes || quotes.length === 0) return undefined;
-    const today = new Date();
-    const dayNumber = Math.floor(today.getTime() / (1000 * 60 * 60 * 24));
-    const index = dayNumber % quotes.length;
-    return quotes[index];
-  }
+private getQuoteOfTheDay(quotes: Quote[]): Quote | undefined {
+  if (!quotes || quotes.length === 0) return undefined;
+
+  const today = new Date();
+
+  const offsetMinutes = today.getTimezoneOffset();
+  const offsetHours = -offsetMinutes / 60;
+
+  const shiftedTime = today.getTime() + offsetHours * 60 * 60 * 1000;
+
+  const dayNumber = Math.floor(shiftedTime / (1000 * 60 * 60 * 24));
+  const index = dayNumber % quotes.length;
+  
+  return quotes[index];
 }
 
-//the calculation is based on UTC time, so the "day" may change at midnight UTC, not local time.
+}
+// The original calculation was based on UTC time, so the "day" would change at midnight UTC,
+// which may be several hours different from local midnight. This could cause the daily quote
+// to switch earlier or later than expected depending on the user's timezone.
 
-//today.getTime() returns the number of milliseconds since January 1, 1970.
+// today.getTime() returns the number of milliseconds since January 1, 1970 UTC.
 
-//Dividing by (1000 * 60 * 60 * 24) converts this to the number of days since that date.
+// Dividing by (1000 * 60 * 60 * 24) converts this to the number of days since that date.
 
-//The Math.floor function rounds down to the nearest whole number, ensuring that we get an integer index.
+// Math.floor rounds down to the nearest whole number, ensuring we get an integer day count.
 
-//The modulo operator (%) is used to ensure that the index wraps around if it exceeds the length of the quotes array. This way, if there are more days than quotes, it will start again from the beginning of the array.
-// This ensures that the same quote is shown for the same day each year, regardless of how many quotes are in the array.
+// The modulo operator (%) wraps the day count around the length of the quotes array,
+// so the quotes cycle repeatedly over days.
 
+// ---
+// Updated implementation shifts the UTC timestamp by the local timezone offset (in hours)
+// dynamically calculated from the user's environment via getTimezoneOffset().
+// This ensures that the "day" number is aligned with the user's local midnight,
+// including automatic handling of daylight saving time changes.
+
+// This way, the daily quote switches exactly at local midnight, no matter the user's timezone,
+// and adjusts automatically for daylight saving time without manual changes.


### PR DESCRIPTION
it:

    Adjusts the day calculation by dynamically applying the user’s local timezone offset (including daylight saving time) to the timestamp.

    Ensures that the daily quote changes exactly at local midnight, not at midnight UTC.

    Automatically handles daylight saving time changes without requiring manual offset adjustments.

    Improves user experience by making the daily quote appear consistent with their local calendar day.

In short:
Switches the quote-of-the-day logic from UTC-based day boundaries to local-time-based day boundaries with automatic DST handling.